### PR TITLE
Make gateway.client.java.demo ready for CE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ DerivedData
 *.x86_64
 *.hex
 
+/target

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,4 @@
+This product depends on Kaazing WebSocket Gateway - Java Client 5.0
+
+	License:	http://www.apache.org/licenses/LICENSE-2.0 (Apache License, Version 2.0)
+	Homepage:	https://github.com/kaazing/gateway.client.java.git

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,3 +2,4 @@ This product depends on Kaazing WebSocket Gateway - Java Client 5.0
 
 	License:	http://www.apache.org/licenses/LICENSE-2.0 (Apache License, Version 2.0)
 	Homepage:	https://github.com/kaazing/gateway.client.java.git
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+Java WebSocket Client Demo
+========================
+
+About this Project
+------------------
+This is a simple maven-based project that shows how to use Kaazing WebSocket Java Client library!
+
+Requirements
+------------
+* Java SE Development Kit (JDK) 7 or higher
+* Maven 3.0.5 or higher
+
+Steps for building this project
+--------------------------------
+0. Clone the repo
+0. mvn clean install

--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ Steps for building this project
 --------------------------------
 0. Clone the repo
 0. mvn clean install
+
+Running the demo from the command-line
+---------------------------------------
+0. cd target
+0. java -cp . -jar gateway.client.java.demo<-5.0.0.1-SNAPSHOT>.jar
+
+Running the demo from within Eclipse
+------------------------------------
+0. Import the project in Eclipse
+0. Right-click on WebSocketFrame.java or WebSocketApplet.java under src/main/java/org.kaazing.net.ws.demo and run!

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Temporary workaround to overcome build related issues.
             <plugin>
                 <groupId>org.kaazing</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -132,6 +133,7 @@
                     <matchWithExisting>false</matchWithExisting>
                 </configuration>
             </plugin>
+            -->
             <plugin>
                 <groupId>com.google.code.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,42 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    Copyright (c) 2007-2008, Kaazing Corporation. All rights reserved.
-
+** This is free and unencumbered software released into the public domain.
+**
+** Anyone is free to copy, modify, publish, use, compile, sell, or
+** distribute this software, either in source code form or as a compiled
+** binary, for any purpose, commercial or non-commercial, and by any
+** means.
+**
+** In jurisdictions that recognize copyright laws, the author or authors
+** of this software dedicate any and all copyright interest in the
+** software to the public domain. We make this dedication for the benefit
+** of the public at large and to the detriment of our heirs and
+** successors. We intend this dedication to be an overt act of
+** relinquishment in perpetuity of all present and future rights to this
+** software under copyright law.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+** OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+** OTHER DEALINGS IN THE SOFTWARE.
+**
+** For more information, please refer to <http://unlicense.org/>
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.kaazing.gateway.core</groupId>
-        <artifactId>com.kaazing.gateway.core.common</artifactId>
-        <version>1.0.0.45</version>
+        <groupId>org.kaazing</groupId>
+        <artifactId>gateway.client.java.common</artifactId>
+        <version>5.1.0.5</version>
     </parent>
 
-    <groupId>com.kaazing.gateway</groupId>
-    <artifactId>com.kaazing.gateway.client.java.demo</artifactId>
+    <groupId>org.kaazing</groupId>
+    <artifactId>gateway.client.java.demo</artifactId>
     <name>Kaazing WebSocket Gateway - Java Client Demo</name>
-    <version>4.0.2.42-SNAPSHOT</version>
+    <version>5.0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <url>https://github.com/kaazing-private/gateway.client.java.demo.git</url>
+    <url>https://github.com/kaazing/gateway.client.java.demo.git</url>
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>git@github.com:kaazing-private/gateway.client.java.demo.git</url>
+        <url>git@github.com:kaazing/gateway.client.java.demo.git</url>
     </scm>
 
     <dependencies>
         <dependency>
-            <groupId>com.kaazing.gateway</groupId>
-            <artifactId>com.kaazing.gateway.client.java</artifactId>
-            <version>[4.0.0.0,4.1.0.0)</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>com.kaazing</groupId>
-            <artifactId>tools.code.signing</artifactId>
-            <version>[4.0.0.0,4.1.0.0)</version>
+            <groupId>org.kaazing</groupId>
+            <artifactId>gateway.client.java</artifactId>
+            <version>[5.0.0.0,5.1.0.0)</version>
             <type>jar</type>
         </dependency>
     </dependencies>
@@ -53,84 +68,36 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
-                                    <include>com.kaazing.gateway:com.kaazing.gateway.client.java</include>
+                                    <include>org.kaazing:gateway.client.java</include>
                                 </includes>
                             </artifactSet>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.kaazing.net.ws.demo.WebSocketFrame</mainClass>
+                                    <mainClass>org.kaazing.net.ws.demo.WebSocketFrame</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jar-plugin</artifactId>
-            <version>2.5</version>
-            <configuration>
-              <archive>
-                <manifest>
-                </manifest>
-                <manifestEntries>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <version>2.5</version>
+              <configuration>
+                <archive>
+                  <manifest>
+                  </manifest>
+                  <manifestEntries>
                     <Trusted-Library>true</Trusted-Library>
                     <Permissions>all-permissions</Permissions>
-                </manifestEntries>
-              </archive>
-            </configuration>
-          </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-code-signing</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>com.kaazing</includeGroupIds>
-                            <includeArtifactIds>tools.code.signing</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>target/codesigning</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jarsigner-plugin</artifactId>
-                <version>1.3.2</version>
-                <executions>
-                    <execution>          
-                        <phase>package</phase>
-                        <id>sign</id>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <keystore>${basedir}/target/codesigning/kaazing-code-signing-cert.pfx</keystore>
-                    <alias>1</alias>
-                    <storetype>pkcs12</storetype>
-                    <storepass>kaazing</storepass>
-                    <arguments>
-                        <argument>-tsa</argument>
-                        <argument>https://timestamp.geotrust.com/tsa</argument>
-                    </arguments>
-                </configuration>
+                  </manifestEntries>
+                </archive>
+              </configuration>
             </plugin>
             <!-- Attach Demo Source Files -->
             <plugin>
@@ -156,12 +123,21 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.kaazing</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.0.0.4</version>
+                <configuration>
+                    <strict>false</strict>
+                    <matchWithExisting>false</matchWithExisting>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.google.code.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
                 <configuration>
                     <useDefaultExcludes>true</useDefaultExcludes>
+                    <failIfMissing>false</failIfMissing>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/assembly/filter.properties
+++ b/src/main/assembly/filter.properties
@@ -1,4 +1,27 @@
 #
-# Copyright (c) 2007-2013, Kaazing Corporation. All rights reserved.
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org/>
 #
 

--- a/src/main/assembly/sources.xml
+++ b/src/main/assembly/sources.xml
@@ -1,8 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    Copyright (c) 2007-2013, Kaazing Corporation. All rights reserved.
-
+** This is free and unencumbered software released into the public domain.
+**
+** Anyone is free to copy, modify, publish, use, compile, sell, or
+** distribute this software, either in source code form or as a compiled
+** binary, for any purpose, commercial or non-commercial, and by any
+** means.
+**
+** In jurisdictions that recognize copyright laws, the author or authors
+** of this software dedicate any and all copyright interest in the
+** software to the public domain. We make this dedication for the benefit
+** of the public at large and to the detriment of our heirs and
+** successors. We intend this dedication to be an overt act of
+** relinquishment in perpetuity of all present and future rights to this
+** software under copyright law.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+** OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+** OTHER DEALINGS IN THE SOFTWARE.
+**
+** For more information, please refer to <http://unlicense.org/>
 -->
 
 <assembly>

--- a/src/main/java/org/kaazing/net/sse/demo/ServerSentEventsApplet.java
+++ b/src/main/java/org/kaazing/net/sse/demo/ServerSentEventsApplet.java
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2007-2013, Kaazing Corporation. All rights reserved.
+ * Copyright (c) 2007-2014, Kaazing Corporation. All rights reserved.
  */
 
-package com.kaazing.net.sse.demo;
+package org.kaazing.net.sse.demo;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -19,10 +19,10 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-import com.kaazing.net.sse.SseEventReader;
-import com.kaazing.net.sse.SseEventSource;
-import com.kaazing.net.sse.SseEventSourceFactory;
-import com.kaazing.net.sse.SseEventType;
+import org.kaazing.net.sse.SseEventReader;
+import org.kaazing.net.sse.SseEventSource;
+import org.kaazing.net.sse.SseEventSourceFactory;
+import org.kaazing.net.sse.SseEventType;
 
 @SuppressWarnings("serial")
 public class ServerSentEventsApplet extends JApplet implements ActionListener {

--- a/src/main/java/org/kaazing/net/ws/demo/LoginDialog.java
+++ b/src/main/java/org/kaazing/net/ws/demo/LoginDialog.java
@@ -1,8 +1,31 @@
 /**
- * Copyright (c) 2007-2013, Kaazing Corporation. All rights reserved.
- */
+** This is free and unencumbered software released into the public domain.
+**
+** Anyone is free to copy, modify, publish, use, compile, sell, or
+** distribute this software, either in source code form or as a compiled
+** binary, for any purpose, commercial or non-commercial, and by any
+** means.
+**
+** In jurisdictions that recognize copyright laws, the author or authors
+** of this software dedicate any and all copyright interest in the
+** software to the public domain. We make this dedication for the benefit
+** of the public at large and to the detriment of our heirs and
+** successors. We intend this dedication to be an overt act of
+** relinquishment in perpetuity of all present and future rights to this
+** software under copyright law.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+** OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+** OTHER DEALINGS IN THE SOFTWARE.
+**
+** For more information, please refer to <http://unlicense.org/>
+*/
 
-package com.kaazing.net.ws.demo;
+package org.kaazing.net.ws.demo;
 
 import java.awt.BorderLayout;
 import java.awt.ComponentOrientation;

--- a/src/main/java/org/kaazing/net/ws/demo/WebSocketApplet.java
+++ b/src/main/java/org/kaazing/net/ws/demo/WebSocketApplet.java
@@ -1,8 +1,31 @@
 /**
- * Copyright (c) 2007-2013, Kaazing Corporation. All rights reserved.
- */
+** This is free and unencumbered software released into the public domain.
+**
+** Anyone is free to copy, modify, publish, use, compile, sell, or
+** distribute this software, either in source code form or as a compiled
+** binary, for any purpose, commercial or non-commercial, and by any
+** means.
+**
+** In jurisdictions that recognize copyright laws, the author or authors
+** of this software dedicate any and all copyright interest in the
+** software to the public domain. We make this dedication for the benefit
+** of the public at large and to the detriment of our heirs and
+** successors. We intend this dedication to be an overt act of
+** relinquishment in perpetuity of all present and future rights to this
+** software under copyright law.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+** OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+** OTHER DEALINGS IN THE SOFTWARE.
+**
+** For more information, please refer to <http://unlicense.org/>
+*/
 
-package com.kaazing.net.ws.demo;
+package org.kaazing.net.ws.demo;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -22,13 +45,13 @@ import javax.swing.JApplet;
 import javax.swing.JList;
 import javax.swing.SwingUtilities;
 
-import com.kaazing.net.auth.BasicChallengeHandler;
-import com.kaazing.net.auth.LoginHandler;
-import com.kaazing.net.http.HttpRedirectPolicy;
-import com.kaazing.net.ws.WebSocket;
-import com.kaazing.net.ws.WebSocketFactory;
-import com.kaazing.net.ws.WebSocketMessageReader;
-import com.kaazing.net.ws.WebSocketMessageType;
+import org.kaazing.net.auth.BasicChallengeHandler;
+import org.kaazing.net.auth.LoginHandler;
+import org.kaazing.net.http.HttpRedirectPolicy;
+import org.kaazing.net.ws.WebSocket;
+import org.kaazing.net.ws.WebSocketFactory;
+import org.kaazing.net.ws.WebSocketMessageReader;
+import org.kaazing.net.ws.WebSocketMessageType;
 
 public class WebSocketApplet extends JApplet {
 
@@ -230,6 +253,7 @@ public class WebSocketApplet extends JApplet {
             locationUrl = "ws://";
         }
 
+        /*
         int port = 8001;
         String host = documentUrl.getHost();
         if (host == null || host.isEmpty()) {
@@ -237,8 +261,10 @@ public class WebSocketApplet extends JApplet {
         } else {
             locationUrl += documentUrl.getHost() + ":" + port;
         }
-        
+
         location.setText(locationUrl + "/echo");
+        */
+        location.setText(locationUrl + "echo.websocket.org");
 
         logModel.setSize(LIST_SIZE);
 
@@ -348,7 +374,7 @@ public class WebSocketApplet extends JApplet {
             locationLabel.setText("Location:");
             locationLabel.setToolTipText("Enter WebSocket Location");
 
-            location.setText("ws://localhost:8001/echo");
+            location.setText("ws://echo.websocket.org");
             location.setToolTipText("Enter the location of the WebSocket");
             location.setColumns(25);
 

--- a/src/main/java/org/kaazing/net/ws/demo/WebSocketFrame.java
+++ b/src/main/java/org/kaazing/net/ws/demo/WebSocketFrame.java
@@ -1,8 +1,31 @@
 /**
- * Copyright (c) 2007-2013, Kaazing Corporation. All rights reserved.
- */
+** This is free and unencumbered software released into the public domain.
+**
+** Anyone is free to copy, modify, publish, use, compile, sell, or
+** distribute this software, either in source code form or as a compiled
+** binary, for any purpose, commercial or non-commercial, and by any
+** means.
+**
+** In jurisdictions that recognize copyright laws, the author or authors
+** of this software dedicate any and all copyright interest in the
+** software to the public domain. We make this dedication for the benefit
+** of the public at large and to the detriment of our heirs and
+** successors. We intend this dedication to be an overt act of
+** relinquishment in perpetuity of all present and future rights to this
+** software under copyright law.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+** OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+** OTHER DEALINGS IN THE SOFTWARE.
+**
+** For more information, please refer to <http://unlicense.org/>
+*/
 
-package com.kaazing.net.ws.demo;
+package org.kaazing.net.ws.demo;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -21,14 +44,14 @@ import javax.swing.JFrame;
 import javax.swing.JList;
 import javax.swing.SwingUtilities;
 
-import com.kaazing.net.auth.BasicChallengeHandler;
-import com.kaazing.net.auth.LoginHandler;
-import com.kaazing.net.http.HttpRedirectPolicy;
-import com.kaazing.net.ws.WebSocket;
-import com.kaazing.net.ws.WebSocketFactory;
-import com.kaazing.net.ws.WebSocketMessageReader;
-import com.kaazing.net.ws.WebSocketMessageType;
-import com.kaazing.net.ws.WebSocketMessageWriter;
+import org.kaazing.net.auth.BasicChallengeHandler;
+import org.kaazing.net.auth.LoginHandler;
+import org.kaazing.net.http.HttpRedirectPolicy;
+import org.kaazing.net.ws.WebSocket;
+import org.kaazing.net.ws.WebSocketFactory;
+import org.kaazing.net.ws.WebSocketMessageReader;
+import org.kaazing.net.ws.WebSocketMessageType;
+import org.kaazing.net.ws.WebSocketMessageWriter;
 
 public class WebSocketFrame extends JFrame {
 
@@ -234,7 +257,7 @@ public class WebSocketFrame extends JFrame {
         });
         p.add(webSocketPanel, BorderLayout.CENTER);
 
-        location.setText("ws://localhost:8001/echo");
+        location.setText("ws://echo.websocket.org");
 
         logModel.setSize(LIST_SIZE);
 
@@ -344,7 +367,7 @@ public class WebSocketFrame extends JFrame {
             locationLabel.setText("Location:");
             locationLabel.setToolTipText("Enter WebSocket Location");
 
-            location.setText("ws://localhost:8001/echo");
+            location.setText("ws://echo.websocket.org");
             location.setToolTipText("Enter the location of the WebSocket");
             location.setColumns(25);
 


### PR DESCRIPTION
1. Update pom.xml to pickup 5.0 dependencies.
2. Unlicense the demo sources and set it free by using the license header from unlicense.org.
3. Change the package names and imports from com.kaazing to org.kaazing.
4. Add a README.md, NOTICE.txt, and LICENSE.txt files.
